### PR TITLE
[Crash] [UICollectionView _Bug_Detected_In_Client_Of_UICollectionViewInvalid_Number_Of_Items_In_Section:] + 96 (UICollectionView.m:11027)

### DIFF
--- a/Sources/ButtonBarPagerTabStripViewController.swift
+++ b/Sources/ButtonBarPagerTabStripViewController.swift
@@ -260,7 +260,15 @@ open class ButtonBarPagerTabStripViewController: PagerTabStripViewController, Pa
                 }
 
             if !indexPathsToReload.isEmpty {
-                buttonBarView.reloadItems(at: indexPathsToReload)
+                DispatchQueue.main.async {
+                    let validIndexPathsToReload = indexPathsToReload.filter {
+                        $0.item >= 0 && $0.item < self.buttonBarView.numberOfItems(inSection: $0.section)
+                    }
+
+                    if !validIndexPathsToReload.isEmpty {
+                        self.buttonBarView.reloadItems(at: validIndexPathsToReload)
+                    }
+                }
             }
         }
 

--- a/Sources/ButtonBarPagerTabStripViewController.swift
+++ b/Sources/ButtonBarPagerTabStripViewController.swift
@@ -235,7 +235,7 @@ open class ButtonBarPagerTabStripViewController: PagerTabStripViewController, Pa
     }
 
     open func updateIndicator(for viewController: PagerTabStripViewController, fromIndex: Int, toIndex: Int, withProgressPercentage progressPercentage: CGFloat, indexWasChanged: Bool) {
-        guard shouldUpdateButtonBarView else { return }
+        guard shouldUpdateButtonBarView, indexWasChanged else { return }
         buttonBarView.move(fromIndex: fromIndex, toIndex: toIndex, progressPercentage: progressPercentage, pagerScroll: .yes)
         if let changeCurrentIndexProgressive = changeCurrentIndexProgressive {
             let oldIndexPath = IndexPath(item: currentIndex != fromIndex ? fromIndex : toIndex, section: 0)


### PR DESCRIPTION
reloadItems 의 indexPath가 존재하는지 판단 후에 업데이트 하도록 수정
main thread에서 reload 하도록 수정
